### PR TITLE
Automerge membrane submodules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,12 @@
   "extends": ["config:recommended"],
   "git-submodules": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchSourceUrlPrefixes": ["https://github.com/membrane-io/"],
+      "groupName": "Membrane hosted packages",
+      "automerge": true
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   },
   "packageRules": [
     {
-      "matchSourceUrlPrefixes": ["https://github.com/membrane-io/"],
+      "matchPackagePrefixes": ["https://github.com/membrane-io"],
       "groupName": "Membrane hosted packages",
       "automerge": true
     }


### PR DESCRIPTION
When the submodules are hosted in `membrane-io`, automerge them because we should've tested/verified them downstream. 